### PR TITLE
Fixes the warnings of cmake 3.17

### DIFF
--- a/cmake/FindKDPart.cmake
+++ b/cmake/FindKDPart.cmake
@@ -31,8 +31,7 @@ find_library(KDPART_LIBRARIES
              PATH_SUFFIXES lib)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(KDPART
+find_package_handle_standard_args(KDPart
                                   DEFAULT_MSG
                                   KDPART_LIBRARIES
                                   KDPART_INCLUDE_DIR)
-

--- a/cmake/FindP4est.cmake
+++ b/cmake/FindP4est.cmake
@@ -40,7 +40,7 @@ list(APPEND P4EST_LIBRARIES ${SC_LIBRARIES})
 
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(P4EST
+find_package_handle_standard_args(P4est
                                   DEFAULT_MSG
                                   P4EST_LIBRARIES
                                   P4EST_INCLUDE_DIR)

--- a/cmake/FindParMETIS.cmake
+++ b/cmake/FindParMETIS.cmake
@@ -37,7 +37,7 @@ find_library(PARMETIS_LIBRARIES
              PATH_SUFFIXES lib)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(PARMETIS
+find_package_handle_standard_args(ParMETIS
                                   DEFAULT_MSG
                                   PARMETIS_LIBRARIES
                                   PARMETIS_INCLUDE_DIR)


### PR DESCRIPTION
Cmake version 3.17.0 issues warnings.

```
CMake Warning (dev) at /usr/share/cmake-3.17/Modules/FindPackageHandleStandardArgs.cmake:272 (message):
  The package name passed to `find_package_handle_standard_args` (KDPART)
  does not match the name of the calling package (KDPart).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/FindKDPart.cmake:34 (find_package_handle_standard_args)
  CMakeLists.txt:38 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found KDPART: /home/conni/tmp/repa/dep/lib/libkdpart.so
CMake Warning (dev) at /usr/share/cmake-3.17/Modules/FindPackageHandleStandardArgs.cmake:272 (message):
  The package name passed to `find_package_handle_standard_args` (P4EST) does
  not match the name of the calling package (P4est).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/FindP4est.cmake:43 (find_package_handle_standard_args)
  CMakeLists.txt:42 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found P4EST: /home/conni/tmp/repa/dep/lib/libp4est.so;/home/conni/tmp/repa/dep/lib/libsc.so
CMake Warning (dev) at /usr/share/cmake-3.17/Modules/FindPackageHandleStandardArgs.cmake:272 (message):
  The package name passed to `find_package_handle_standard_args` (PARMETIS)
  does not match the name of the calling package (ParMETIS).  This can lead
  to problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/FindParMETIS.cmake:40 (find_package_handle_standard_args)
  CMakeLists.txt:46 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Patch should fix this.
Tested with cmake 3.17.0 on arch and cmake 3.16.5 on ubuntu.