### PR TITLE
Merges SO and SOF. Fixes SOF iterating part

### DIFF
--- a/repa/grids/diff_variants.cpp
+++ b/repa/grids/diff_variants.cpp
@@ -122,80 +122,42 @@ SOVolumeComputation::compute_flow(boost::mpi::communicator neighcomm,
 
     double alpha = 1.0 / nneigh;
 
-    // Exchange load in local neighborhood
-    std::vector<double> neighloads(nneigh);
-    MPI_Neighbor_allgather(&load, 1, MPI_DOUBLE, neighloads.data(), 1,
-                           MPI_DOUBLE, neighcomm);
-
-    if (_prev_deficiency.size() == 0) {
-        for (int j = 0; j < neighloads.size(); j++)
-            deficiency[j] = alpha * (load - neighloads[j]);
-
-        _prev_deficiency.reserve(nneigh);
-        for (int i = 0; i < nneigh; i++)
-            _prev_deficiency[neighbors[i]] = deficiency[i];
-    }
-    else {
-        for (int j = 0; j < neighloads.size(); j++)
-            deficiency[j] = (_beta - 1) * _prev_deficiency[neighbors[j]]
-                            + _beta * alpha * (load - neighloads[j]);
-
-        for (int i = 0; i < nneigh; i++)
-            _prev_deficiency[neighbors[i]] = deficiency[i];
-    }
-
-    return deficiency;
-}
-
-void SOVolumeComputation::set_beta_value(double beta_value)
-{
-    _beta = beta_value;
-}
-
-PerNeighbor<double>
-SOFVolumeComputation::compute_flow(boost::mpi::communicator neighcomm,
-                                   const std::vector<rank_type> &neighbors,
-                                   double load) const
-{
-    int nneigh = util::mpi_undirected_neighbor_count(neighcomm);
-
-    std::vector<double> deficiency(nneigh);
-
-    double alpha = 1.0 / nneigh;
-
-    // Exchange load in local neighborhood
-    std::vector<double> neighloads(nneigh);
-    MPI_Neighbor_allgather(&load, 1, MPI_DOUBLE, neighloads.data(), 1,
-                           MPI_DOUBLE, neighcomm);
-
     for (int i = 0; i < _nflow_iter; i++) {
-        if (_prev_deficiency.size() == 0) {
-            for (int j = 0; j < neighloads.size(); j++)
-                deficiency[j] = alpha * (load - neighloads[j]);
+        // Exchange load in local neighborhood
+        std::vector<double> neighloads(nneigh);
+        MPI_Neighbor_allgather(&load, 1, MPI_DOUBLE, neighloads.data(), 1,
+                               MPI_DOUBLE, neighcomm);
 
+        double old_load = load;
+        if (_prev_deficiency.size() == 0) {
             _prev_deficiency.reserve(nneigh);
-            for (int j = 0; j < nneigh; j++)
-                _prev_deficiency[neighbors[j]] = deficiency[j];
+            for (int j = 0; j < neighbors.size(); j++) {
+                double new_f = alpha * (old_load - neighloads[j]);
+                deficiency[j] += new_f;
+                load -= new_f;
+                _prev_deficiency[neighbors[j]] = new_f;
+            }
         }
         else {
-            for (int j = 0; j < neighloads.size(); j++)
-                deficiency[j] = (_beta - 1) * _prev_deficiency[neighbors[j]]
-                                + _beta * alpha * (load - neighloads[j]);
-
-            for (int j = 0; j < nneigh; j++)
-                _prev_deficiency[neighbors[j]] = deficiency[j];
+            for (int j = 0; j < neighbors.size(); j++) {
+                double new_f = (_beta - 1) * _prev_deficiency[neighbors[j]]
+                               + _beta * alpha * (old_load - neighloads[j]);
+                deficiency[j] += new_f;
+                load -= new_f;
+                _prev_deficiency[neighbors[j]] = new_f;
+            }
         }
     }
 
     return deficiency;
 }
 
-void SOFVolumeComputation::set_n_flow_iter(uint32_t nflow_iter)
+void SOVolumeComputation::set_n_flow_iter(uint32_t nflow_iter)
 {
     _nflow_iter = nflow_iter;
 }
 
-void SOFVolumeComputation::set_beta_value(double beta_value)
+void SOVolumeComputation::set_beta_value(double beta_value)
 {
     _beta = beta_value;
 }
@@ -206,7 +168,6 @@ static const std::map<FlowCalcKind, FlowCreateFunction> flow_create_function_map
         {FlowCalcKind::WILLEBEEK, []() { return new WLMVolumeComputation(); }},
         {FlowCalcKind::SCHORN, []() { return new SchornVolumeComputation(); }},
         {FlowCalcKind::SO, []() { return new SOVolumeComputation(); }},
-        {FlowCalcKind::SOF, []() { return new SOFVolumeComputation(); }},
 };
 
 std::unique_ptr<FlowCalculator> create_flow_calc(FlowCalcKind kind)

--- a/repa/grids/diff_variants.hpp
+++ b/repa/grids/diff_variants.hpp
@@ -126,29 +126,6 @@ protected:
 
 /*
  * This implementation is adapted from [Muthukrishnan, Ghosh and Schultz, Theory
- * of Computing Systems volume 31, pp. 331–354(1998)].
- *
- * Beta will be set with set_beta_value(double beta_value), by using
- * dd.command("set beta <value>")
- * Beta Default: 1.8
- */
-struct SOVolumeComputation : public FlowCalculator, public BetaValueSetter {
-    virtual PerNeighbor<double>
-    compute_flow(boost::mpi::communicator neighcomm,
-                 const std::vector<rank_type> &neighbors,
-                 double load) const override;
-
-    virtual void set_beta_value(double beta_value) override;
-
-protected:
-    double _beta = 1.8;
-
-private:
-    mutable std::unordered_map<rank_type, double> _prev_deficiency;
-};
-
-/*
- * This implementation is adapted from [Muthukrishnan, Ghosh and Schultz, Theory
  * of Computing Systems volume 31, pages331–354(1998)] with a minor change.
  *
  * Beta will be set with set_beta_value(double beta_value), by using
@@ -160,9 +137,9 @@ private:
  * This method will be called when using dd.command("set flow_count 15").
  * Flow Default is 1.
  */
-struct SOFVolumeComputation : public FlowCalculator,
-                              public FlowIterSetter,
-                              public BetaValueSetter {
+struct SOVolumeComputation : public FlowCalculator,
+                             public FlowIterSetter,
+                             public BetaValueSetter {
     virtual PerNeighbor<double>
     compute_flow(boost::mpi::communicator neighcomm,
                  const std::vector<rank_type> &neighbors,
@@ -179,7 +156,7 @@ private:
     mutable std::unordered_map<rank_type, double> _prev_deficiency;
 };
 
-enum class FlowCalcKind { WILLEBEEK, SCHORN, SO, SOF };
+enum class FlowCalcKind { WILLEBEEK, SCHORN, SO };
 std::unique_ptr<FlowCalculator> create_flow_calc(FlowCalcKind);
 
 } // namespace diff_variants

--- a/repa/grids/psdiffusion.cpp
+++ b/repa/grids/psdiffusion.cpp
@@ -40,8 +40,7 @@ namespace grids {
 
 static const std::unordered_map<std::string, diff_variants::FlowCalcKind>
     supported_ps_diffusion_variants
-    = {{"so", diff_variants::FlowCalcKind::SO},
-       {"sof", diff_variants::FlowCalcKind::SOF}};
+    = {{"so", diff_variants::FlowCalcKind::SO}};
 
 /** Returns the new Coords of a Rank after it beeing maped to opposite site.
  * This is a necessary step for the metric because of the periodic edge.


### PR DESCRIPTION
This PR includes a merge of SO and SOF to reduce code duplication. Also the changes to SOF diffusion, which now works correctly. A flow value of 1 is default, which means that SO is executed.

The following simulations were done with soot-3.2M. Prechanges here is the current version without _prev_deficiency <- deficiency; at the end. Postchanges includes this change. It was executed with 02 and 15 flow iterations.

## 02 Flow Iterations
![pre_post_02_plt_Imbalance-1](https://user-images.githubusercontent.com/15233006/83440836-df0b9b80-a445-11ea-8635-de026598fc2f.png)
![pre_post_02_plt_RepartTime-1](https://user-images.githubusercontent.com/15233006/83440843-e29f2280-a445-11ea-8c22-b6d222d30464.png)

## 15 Flow Iterations

The use of postchanges 15 was eventually aborted because it became useless. 

![pre_post_15_plt_Imbalance-1](https://user-images.githubusercontent.com/15233006/83440881-f185d500-a445-11ea-9bdf-2c7d99eeca24.png)
![pre_post_15_plt_RepartTime-1](https://user-images.githubusercontent.com/15233006/83440891-f3e82f00-a445-11ea-9541-b8b5b8f03054.png)

## Log files as reference
[postchanges.txt](https://github.com/hirschsn/repa/files/4712843/postchanges.txt)
[postchanges_02.txt](https://github.com/hirschsn/repa/files/4712844/postchanges_02.txt)
[prechanges.txt](https://github.com/hirschsn/repa/files/4712845/prechanges.txt)
[prechanges_02.txt](https://github.com/hirschsn/repa/files/4712846/prechanges_02.txt)
