### PR TITLE
Enable a completely local reinit for Diffusion

### DIFF
--- a/repa/grids/diffusion.hpp
+++ b/repa/grids/diffusion.hpp
@@ -67,6 +67,9 @@ protected:
         return r;
     }
 
+    virtual std::vector<global_cell_index_type>
+    compute_new_local_cells() const override;
+
     std::set<global_cell_index_type> get_ghost_layer_cells() const;
 
     //
@@ -116,6 +119,12 @@ private:
     friend struct HybridGPDiff; // Needs access to "partition" vector
 
     double profit_percentage_pass_through = 1.0;
+
+    /** This vector keeps track of all local cells during the repartition
+     * process in order to efficiently implement "compute_new_local_cells".
+     * Don't use it for something else.
+     */
+    std::set<global_cell_index_type> _local_cell_indices;
 
     void pre_init(bool firstcall) override;
     void init_new_foreign_cell(local_cell_index_type localcell,

--- a/repa/grids/glomethod.cpp
+++ b/repa/grids/glomethod.cpp
@@ -130,6 +130,17 @@ GloMethod::~GloMethod()
 {
 }
 
+std::vector<global_cell_index_type> GloMethod::compute_new_local_cells() const
+{
+    std::vector<global_cell_index_type> res;
+    for (const auto i : gbox.global_cells()) {
+        if (auto r = rank_of_cell(i); r && *r == comm_cart.rank()) {
+            res.push_back(i);
+        }
+    }
+    return res;
+}
+
 /*
  * Rebuild the data structures describing subdomain and communication.
  */
@@ -139,12 +150,7 @@ void GloMethod::init(bool firstcall)
     cell_store.clear();
     neighbors.clear();
 
-    // Extract the local cells from "partition".
-    for (const auto i : gbox.global_cells()) {
-        if (auto r = rank_of_cell(i); r && *r == comm_cart.rank()) {
-            cell_store.push_back_local(i);
-        }
-    }
+    cell_store.bulk_register_local_cells(compute_new_local_cells());
 
     //
     // In the following, we first collect the communication volume as global

--- a/repa/grids/glomethod.hpp
+++ b/repa/grids/glomethod.hpp
@@ -54,6 +54,8 @@ struct GloMethod : public ParallelLCGrid {
     global_hash(local_or_ghost_cell_index_type cellidx) override;
 
 protected:
+    friend struct HybridGPDiff;
+
     local_cell_index_type n_local_cells() const override;
     ghost_cell_index_type n_ghost_cells() const override;
 
@@ -107,6 +109,12 @@ protected:
                                        rank_type owner)
     {
     }
+
+    // For re-initialization, computes the new set of local cells
+    // owned by this process/subdomain.
+    // Override this if the subclass can do this more efficiently.
+    // @returns Vector of global indices of the new local cells
+    virtual std::vector<global_cell_index_type> compute_new_local_cells() const;
 
     // Function that globally resolves a cell index to a rank.
     // Return value may be empty if cell "idx" is irrelevant for

--- a/repa/grids/hybrid-gp-diff.cpp
+++ b/repa/grids/hybrid-gp-diff.cpp
@@ -137,6 +137,9 @@ void HybridGPDiff::switch_implementation()
         graph_impl.init();
         break;
     case State::DIFF:
+        // The state of the diffusive implementation is not only given by
+        // the "partition" field but also by the set of local cell indices.
+        // We need to explicitly recompute the latter.
         active_implementation = &diff_impl;
         std::copy(std::begin(graph_impl.partition),
                   std::end(graph_impl.partition),
@@ -145,6 +148,9 @@ void HybridGPDiff::switch_implementation()
         for (const auto &el : graph_impl.partition)
             assert(el >= 0 && el < comm.size());
 #endif
+        diff_impl._local_cell_indices.clear();
+        auto data = diff_impl.GloMethod::compute_new_local_cells();
+        diff_impl._local_cell_indices.insert(data.begin(), data.end());
         diff_impl.init();
         break;
     }

--- a/repa/grids/util/global_index_storage.hpp
+++ b/repa/grids/util/global_index_storage.hpp
@@ -58,6 +58,19 @@ struct global_index_storage {
         _local_cells.push_back(g);
     }
 
+    /** Alternative to "push_back_local" if all local cells are given
+     * in an array.
+     */
+    void bulk_register_local_cells(std::vector<global_cell_index_type> &&cs)
+    {
+        assert(_local_cells.empty());
+        _local_cells = std::move(cs);
+        size_t i = 0;
+        for (const auto &g : _local_cells) {
+            _inverse_map.emplace(g, local_cell_index_type{i++});
+        }
+    }
+
     /** Registers a new ghost cell index
      *
      * @param g global index of the new ghost cell


### PR DESCRIPTION
Introduce new interface "compute_new_local_cells" in GloMethod that
diffusion can override and return custom book keeping data.