### PR TITLE
Seamless integration with FetchContent

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ build-debug:
     stage: build
     script:
         - mkdir build && cd build
-        - cmake .. -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy)" -DCMAKE_BUILD_TYPE=Debug -DWITH_COVERAGE=off -DMPIEXEC_PREFLAGS="--oversubscribe;--bind-to;none"
+        - cmake .. -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy)" -DCMAKE_BUILD_TYPE=Debug -DREPA_WITH_COVERAGE=off -DMPIEXEC_PREFLAGS="--oversubscribe;--bind-to;none"
         - make -j4
     artifacts:
         paths:
@@ -38,7 +38,7 @@ build-relwithdebinfo:
     stage: build
     script:
         - mkdir build && cd build
-        - cmake .. -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy)" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_COVERAGE=off -DMPIEXEC_PREFLAGS="--oversubscribe;--bind-to;none"
+        - cmake .. -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy)" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DREPA_WITH_COVERAGE=off -DMPIEXEC_PREFLAGS="--oversubscribe;--bind-to;none"
         - make -j4
     artifacts:
         paths:
@@ -55,7 +55,7 @@ build-release:
     stage: build
     script:
         - mkdir build && cd build
-        - cmake .. -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy)" -DCMAKE_BUILD_TYPE=Release -DWITH_COVERAGE=off -DMPIEXEC_PREFLAGS="--oversubscribe;--bind-to;none"
+        - cmake .. -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy)" -DCMAKE_BUILD_TYPE=Release -DREPA_WITH_COVERAGE=off -DMPIEXEC_PREFLAGS="--oversubscribe;--bind-to;none"
         - make -j4
     artifacts:
         paths:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,8 +91,8 @@ if(WITH_TESTS AND WITH_COVERAGE)
       set(CMAKE_EXE_LINKER_FLAGS "--coverage -fprofile-arcs -ftest-coverage")
 
       add_custom_target(coverage
-                        COMMAND ${CMAKE_SOURCE_DIR}/util/coverage.sh
-                        WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+                        COMMAND ${PROJECT_SOURCE_DIR}/util/coverage.sh
+                        WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
       message(STATUS "Coverage enabled. Use `coverage' target after build to execute coverage tests.")
     endif()
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,33 +25,33 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-option(WITH_KDPART "Build with ORB LB support" ON)
-option(WITH_P4EST "Build with SFC LB support" ON)
-option(WITH_PARMETIS "Build with graph partitioning LB support" ON)
-option(WITH_KDPART "Build with kd grid support" ON)
+option(REPA_WITH_KDPART "Build with ORB LB support" ON)
+option(REPA_WITH_P4EST "Build with SFC LB support" ON)
+option(REPA_WITH_PARMETIS "Build with graph partitioning LB support" ON)
+option(REPA_WITH_KDPART "Build with kd grid support" ON)
 
-option(WITH_TESTS "Perform unit tests" ON)
-option(WITH_COVERAGE "Coverage for tests" OFF)
+option(REPA_WITH_TESTS "Perform unit tests" ON)
+option(REPA_WITH_COVERAGE "Coverage for tests" OFF)
 
-if(WITH_KDPART)
+if(REPA_WITH_KDPART)
   find_package(KDPart REQUIRED)
-endif(WITH_KDPART)
+endif(REPA_WITH_KDPART)
 
-if(WITH_P4EST)
+if(REPA_WITH_P4EST)
   find_package(P4est REQUIRED)
-endif(WITH_P4EST)
+endif(REPA_WITH_P4EST)
 
-if(WITH_PARMETIS)
+if(REPA_WITH_PARMETIS)
   find_package(ParMETIS REQUIRED)
-endif(WITH_PARMETIS)
+endif(REPA_WITH_PARMETIS)
 
 find_package(MPI REQUIRED)
 include_directories(SYSTEM ${MPI_CXX_INCLUDE_PATH})
 
 list(APPEND REQ_BOOST_PACKAGES mpi serialization)
-if(WITH_TESTS)
+if(REPA_WITH_TESTS)
   list(APPEND REQ_BOOST_PACKAGES unit_test_framework)
-endif(WITH_TESTS)
+endif(REPA_WITH_TESTS)
 find_package(Boost "1.67.0" REQUIRED ${REQ_BOOST_PACKAGES})
 
 if (Boost_VERSION VERSION_GREATER_EQUAL "1.69" AND Boost_VERSION VERSION_LESS_EQUAL "1.71")
@@ -77,7 +77,7 @@ set(REPA_DEFAULT_COMPILE_OPTIONS
       "-Wno-conversion"
       "-Wno-sign-conversion" >)
 
-if(WITH_TESTS AND WITH_COVERAGE)
+if(REPA_WITH_TESTS AND REPA_WITH_COVERAGE)
   if (NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
     message(SEND_ERROR "COVERAGE is only possible with Gnu Compiler Collection.")
   else()
@@ -96,16 +96,16 @@ if(WITH_TESTS AND WITH_COVERAGE)
       message(STATUS "Coverage enabled. Use `coverage' target after build to execute coverage tests.")
     endif()
   endif()
-endif(WITH_TESTS AND WITH_COVERAGE)
+endif(REPA_WITH_TESTS AND REPA_WITH_COVERAGE)
 
 add_subdirectory(repa)
 
-if(WITH_TESTS)
+if(REPA_WITH_TESTS)
   set(TEST_MAX_NPROC 4
       CACHE STRING "Maximum number of processes to run the tests with")
   enable_testing()
   add_subdirectory(tests)
-endif(WITH_TESTS)
+endif(REPA_WITH_TESTS)
 
 add_subdirectory(examples)
 

--- a/cmake/define_example.cmake
+++ b/cmake/define_example.cmake
@@ -38,7 +38,7 @@ function(define_example)
                                   Boost::serialization)
 
     target_include_directories(${EXAMPLE_NAME}
-                               PRIVATE ${CMAKE_SOURCE_DIR})
+                               PRIVATE ${PROJECT_SOURCE_DIR})
     target_compile_options(${EXAMPLE_NAME}
                            PRIVATE ${REPA_DEFAULT_COMPILE_OPTIONS})
 endfunction(define_example)

--- a/cmake/define_test.cmake
+++ b/cmake/define_test.cmake
@@ -40,7 +40,7 @@ function(define_test)
                                   ${TEST_LIBRARIES})
 
     target_include_directories(${TEST_NAME}
-                               PRIVATE ${CMAKE_SOURCE_DIR})
+                               PRIVATE ${PROJECT_SOURCE_DIR})
     target_compile_options(${TEST_NAME}
                            PRIVATE ${REPA_DEFAULT_COMPILE_OPTIONS})
 

--- a/repa/CMakeLists.txt
+++ b/repa/CMakeLists.txt
@@ -32,24 +32,24 @@ set(repa_SRC
     pargrid.cpp
 )
 
-if(WITH_KDPART AND KDPART_FOUND)
+if(REPA_WITH_KDPART AND KDPART_FOUND)
   set(repa_SRC
       ${repa_SRC}
       grids/kd_tree.cpp)
-endif(WITH_KDPART AND KDPART_FOUND)
+endif(REPA_WITH_KDPART AND KDPART_FOUND)
 
-if(WITH_P4EST AND P4EST_FOUND)
+if(REPA_WITH_P4EST AND P4EST_FOUND)
   set(repa_SRC
       ${repa_SRC}
       grids/p4est.cpp)
-endif(WITH_P4EST AND P4EST_FOUND)
+endif(REPA_WITH_P4EST AND P4EST_FOUND)
 
-if(WITH_PARMETIS AND PARMETIS_FOUND)
+if(REPA_WITH_PARMETIS AND PARMETIS_FOUND)
   set(repa_SRC
       ${repa_SRC}
       grids/graph.cpp
       grids/hybrid-gp-diff.cpp)
-endif(WITH_PARMETIS AND PARMETIS_FOUND)
+endif(REPA_WITH_PARMETIS AND PARMETIS_FOUND)
 
 set(repa_HDR
     repa.hpp
@@ -66,25 +66,25 @@ set(repa_HDR
 
 add_library(repa SHARED ${repa_SRC})
 
-if(WITH_KDPART AND KDPART_FOUND)
+if(REPA_WITH_KDPART AND KDPART_FOUND)
   target_include_directories(repa PRIVATE ${KDPART_INCLUDE_DIR})
   target_link_libraries(repa PRIVATE ${KDPART_LIBRARIES})
   add_definitions(-DHAVE_KDPART)
-endif(WITH_KDPART AND KDPART_FOUND)
+endif(REPA_WITH_KDPART AND KDPART_FOUND)
 
-if(WITH_P4EST AND P4EST_FOUND)
+if(REPA_WITH_P4EST AND P4EST_FOUND)
   target_include_directories(repa PRIVATE ${P4EST_INCLUDE_DIR})
   target_link_libraries(repa PRIVATE ${P4EST_LIBRARIES})
   add_definitions(-DHAVE_P4EST)
-endif(WITH_P4EST AND P4EST_FOUND)
+endif(REPA_WITH_P4EST AND P4EST_FOUND)
 
-if(WITH_PARMETIS AND PARMETIS_FOUND)
+if(REPA_WITH_PARMETIS AND PARMETIS_FOUND)
   target_include_directories(repa
                              PRIVATE ${PARMETIS_INCLUDE_DIR}
                                      ${METIS_INCLUDE_DIR})
   target_link_libraries(repa PRIVATE ${PARMETIS_LIBRARIES})
   add_definitions(-DHAVE_PARMETIS)
-endif(WITH_PARMETIS AND PARMETIS_FOUND)
+endif(REPA_WITH_PARMETIS AND PARMETIS_FOUND)
 
 target_link_libraries(repa
                       PUBLIC ${MPI_CXX_LIBRARIES}


### PR DESCRIPTION
Allow populating the repa project in a parent project via the `FetchContent` method, which uses a common `CMakeCache.txt` file to manage the state of the parent project and all populated projects. Replace CMake relative paths by project-specific relative paths and add a prefix to the repa project options to avoid name collisions with the options of the parent project and the other populated projects.